### PR TITLE
Allow for email templates path to be configurable

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -14,23 +15,28 @@ import (
 
 const (
 	// Email templates must be provided in this directory and are loaded at compile time
-	templatesDir = "templates"
+	defaultTemplatesDir = "templates"
 
 	// Partials are included when rendering templates for composability and reuse - includes footer, header, etc.
-	partialsDir = "partials"
+	defaultPartialsDir = "partials"
 )
 
 var (
 	//go:embed templates/*.html templates/*.txt templates/partials/*html
 	files     embed.FS
 	templates map[string]*template.Template
+
+	// Shared function map
+	fm = template.FuncMap{
+		"ToUpper": strcase.UpperCamelCase,
+	}
 )
 
 // Load templates when the package is imported
 func init() {
 	templates = make(map[string]*template.Template)
 
-	templateFiles, err := fs.ReadDir(files, templatesDir)
+	templateFiles, err := fs.ReadDir(files, defaultTemplatesDir)
 	if err != nil {
 		log.Panic().Err(err).Msg("could not read template files")
 	}
@@ -44,15 +50,10 @@ func init() {
 
 		// Each template will be accessible by its base name in the global map
 		patterns := make([]string, 0, 2) //nolint:mnd
-		patterns = append(patterns, filepath.Join(templatesDir, file.Name()))
+		patterns = append(patterns, filepath.Join(defaultTemplatesDir, file.Name()))
 
 		if filepath.Ext(file.Name()) == ".html" {
-			patterns = append(patterns, filepath.Join(templatesDir, partialsDir, "*.html"))
-		}
-
-		// function map for template
-		fm := template.FuncMap{
-			"ToUpper": strcase.UpperCamelCase,
+			patterns = append(patterns, filepath.Join(defaultTemplatesDir, defaultPartialsDir, "*.html"))
 		}
 
 		var err error
@@ -62,6 +63,33 @@ func init() {
 			log.Panic().Err(err).Str("template", file.Name()).Msg("could not parse template")
 		}
 	}
+}
+
+func loadCustomTemplatePath(templatePath string) error {
+	templateFiles, err := fs.ReadDir(os.DirFS(templatePath), ".")
+	if err != nil {
+		return fmt.Errorf("could not read template files from %q: %w", templatePath, err)
+	}
+
+	for _, file := range templateFiles {
+		if file.IsDir() {
+			continue
+		}
+
+		pattern := filepath.Join(templatePath, file.Name())
+
+		tmpl, err := template.New(file.Name()).
+			Funcs(fm).
+			ParseFiles(pattern)
+
+		if err != nil {
+			return fmt.Errorf("could not parse template %q: %w", file.Name(), err)
+		}
+
+		templates[file.Name()] = tmpl
+	}
+
+	return nil
 }
 
 // Render returns the text and html executed templates for the specified name and data

--- a/builder.go
+++ b/builder.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -63,33 +62,6 @@ func init() {
 			log.Panic().Err(err).Str("template", file.Name()).Msg("could not parse template")
 		}
 	}
-}
-
-func loadCustomTemplatePath(templatePath string) error {
-	templateFiles, err := os.ReadDir(templatePath)
-	if err != nil {
-		return fmt.Errorf("could not read template files from %q: %w", templatePath, err)
-	}
-
-	for _, file := range templateFiles {
-		if file.IsDir() {
-			continue
-		}
-
-		pattern := filepath.Join(templatePath, file.Name())
-
-		tmpl, err := template.New(file.Name()).
-			Funcs(fm).
-			ParseFiles(pattern)
-
-		if err != nil {
-			return fmt.Errorf("could not parse template %q: %w", file.Name(), err)
-		}
-
-		templates[file.Name()] = tmpl
-	}
-
-	return nil
 }
 
 // Render returns the text and html executed templates for the specified name and data

--- a/builder.go
+++ b/builder.go
@@ -66,7 +66,7 @@ func init() {
 }
 
 func loadCustomTemplatePath(templatePath string) error {
-	templateFiles, err := fs.ReadDir(os.DirFS(templatePath), ".")
+	templateFiles, err := os.ReadDir(templatePath)
 	if err != nil {
 		return fmt.Errorf("could not read template files from %q: %w", templatePath, err)
 	}

--- a/email.go
+++ b/email.go
@@ -8,6 +8,10 @@ import (
 
 // NewVerifyEmail returns a new email message based on the config values and the provided recipient and token
 func (c Config) NewVerifyEmail(r Recipient, token string) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := VerifyEmailData{
 		EmailData: EmailData{
 			Config:    c,
@@ -27,6 +31,10 @@ func (c Config) NewVerifyEmail(r Recipient, token string) (*newman.EmailMessage,
 
 // NewWelcomeEmail returns a new email message based on the config values and the provided recipient and organization name
 func (c Config) NewWelcomeEmail(r Recipient, org string) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := WelcomeData{
 		EmailData: EmailData{
 			Config:    c,
@@ -47,6 +55,10 @@ type InviteTemplateData struct {
 
 // NewInviteEmail returns a new email message based on the config values and the provided recipient and invite data
 func (c Config) NewInviteEmail(r Recipient, i InviteTemplateData, token string) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := c.newInvite(r, i)
 
 	data.Recipient = r
@@ -63,6 +75,10 @@ func (c Config) NewInviteEmail(r Recipient, i InviteTemplateData, token string) 
 
 // NewInviteEmail returns a new email message based on the config values and the provided recipient and invite data
 func (c Config) NewInviteAcceptedEmail(r Recipient, i InviteTemplateData) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := c.newInvite(r, i)
 
 	return inviteAccepted(data)
@@ -85,6 +101,10 @@ func (c Config) newInvite(r Recipient, i InviteTemplateData) InviteData {
 
 // NewPasswordResetRequestEmail returns a new email message based on the config values and the provided recipient and token
 func (c Config) NewPasswordResetRequestEmail(r Recipient, token string) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := ResetRequestData{
 		EmailData: EmailData{
 			Config:    c,
@@ -104,6 +124,10 @@ func (c Config) NewPasswordResetRequestEmail(r Recipient, token string) (*newman
 
 // NewPasswordResetSuccessEmail returns  a new email message based on the config values and the provided recipient
 func (c Config) NewPasswordResetSuccessEmail(r Recipient) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := ResetSuccessData{
 		EmailData: EmailData{
 			Config:    c,
@@ -116,6 +140,10 @@ func (c Config) NewPasswordResetSuccessEmail(r Recipient) (*newman.EmailMessage,
 
 // NewSubscriberEmail returns a new email message based on the config values and the provided recipient, organization name, and token
 func (c Config) NewSubscriberEmail(r Recipient, organizationName, token string) (*newman.EmailMessage, error) {
+	if err := ensureCustomTemplatesLoaded(c.TemplatesPath); err != nil {
+		return nil, err
+	}
+
 	data := SubscriberEmailData{
 		EmailData: EmailData{
 			Config:    c,

--- a/options.go
+++ b/options.go
@@ -17,12 +17,7 @@ func New(options ...Option) (*Config, error) {
 		option(c)
 	}
 
-	switch len(c.templatesPath) {
-	case 0:
-		return nil, errors.New("please provide your templates path")
-
-	default:
-
+	if c.templatesPath != defaultTemplatesDir {
 		if err := loadCustomTemplatePath(c.templatesPath); err != nil {
 			return nil, err
 		}

--- a/options.go
+++ b/options.go
@@ -5,6 +5,13 @@ import (
 	"net/mail"
 )
 
+var (
+	ErrMissingCompanyAddress = errors.New("please provide your company's address")
+	ErrMissingCompanyName    = errors.New("please provide your company's name")
+	ErrMissingSenderEmail    = errors.New("please provide your sender email")
+	ErrInvalidSenderEmail    = errors.New("please provide a valid sender email ( from email )")
+)
+
 // New is a function that creates a new config for the email templates
 func New(options ...Option) (*Config, error) {
 	// initialize the resendEmailSender
@@ -24,19 +31,19 @@ func New(options ...Option) (*Config, error) {
 	}
 
 	if len(c.CompanyAddress) == 0 {
-		return nil, errors.New("please provide your company's address")
+		return nil, ErrMissingCompanyAddress
 	}
 
 	if len(c.CompanyName) == 0 {
-		return nil, errors.New("please provide your company's name")
+		return nil, ErrMissingCompanyName
 	}
 
 	if len(c.FromEmail) == 0 {
-		return nil, errors.New("please provide your sender email")
+		return nil, ErrMissingSenderEmail
 	}
 
 	if _, err := mail.ParseAddress(c.FromEmail); err != nil {
-		return nil, errors.New("please provide a valid sender email ( from email )")
+		return nil, ErrInvalidSenderEmail
 	}
 
 	return c, nil

--- a/options.go
+++ b/options.go
@@ -6,10 +6,7 @@ import (
 )
 
 var (
-	ErrMissingCompanyAddress = errors.New("please provide your company's address")
-	ErrMissingCompanyName    = errors.New("please provide your company's name")
-	ErrMissingSenderEmail    = errors.New("please provide your sender email")
-	ErrInvalidSenderEmail    = errors.New("please provide a valid sender email ( from email )")
+	ErrInvalidSenderEmail = errors.New("please provide a valid sender email ( from email )")
 )
 
 // New is a function that creates a new config for the email templates
@@ -24,22 +21,22 @@ func New(options ...Option) (*Config, error) {
 		option(c)
 	}
 
-	if c.templatesPath != defaultTemplatesDir {
+	if c.templatesPath != defaultTemplatesDir && len(c.templatesPath) != 0 {
 		if err := loadCustomTemplatePath(c.templatesPath); err != nil {
 			return nil, err
 		}
 	}
 
 	if len(c.CompanyAddress) == 0 {
-		return nil, ErrMissingCompanyAddress
+		return nil, newMissingRequiredFieldError("company address")
 	}
 
 	if len(c.CompanyName) == 0 {
-		return nil, ErrMissingCompanyName
+		return nil, newMissingRequiredFieldError("company name")
 	}
 
 	if len(c.FromEmail) == 0 {
-		return nil, ErrMissingSenderEmail
+		return nil, newMissingRequiredFieldError("sender email")
 	}
 
 	if _, err := mail.ParseAddress(c.FromEmail); err != nil {

--- a/options.go
+++ b/options.go
@@ -59,11 +59,11 @@ func (c *Config) validate() error {
 		}
 	}
 
-	if len(c.CompanyAddress) == 0 {
+	if c.CompanyAddress == "" {
 		return newMissingRequiredFieldError("company address")
 	}
 
-	if len(c.CompanyName) == 0 {
+	if c.CompanyName == "" {
 		return newMissingRequiredFieldError("company name")
 	}
 

--- a/options.go
+++ b/options.go
@@ -1,13 +1,47 @@
 package emailtemplates
 
+import (
+	"errors"
+	"net/mail"
+)
+
 // New is a function that creates a new config for the email templates
 func New(options ...Option) (*Config, error) {
 	// initialize the resendEmailSender
-	c := &Config{}
+	c := &Config{
+		templatesPath: defaultTemplatesDir,
+	}
 
 	// apply the options
 	for _, option := range options {
 		option(c)
+	}
+
+	switch len(c.templatesPath) {
+	case 0:
+		return nil, errors.New("please provide your templates path")
+
+	default:
+
+		if err := loadCustomTemplatePath(c.templatesPath); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(c.CompanyAddress) == 0 {
+		return nil, errors.New("please provide your company's address")
+	}
+
+	if len(c.CompanyName) == 0 {
+		return nil, errors.New("please provide your company's name")
+	}
+
+	if len(c.FromEmail) == 0 {
+		return nil, errors.New("please provide your sender email")
+	}
+
+	if _, err := mail.ParseAddress(c.FromEmail); err != nil {
+		return nil, errors.New("please provide a valid sender email ( from email )")
 	}
 
 	return c, nil
@@ -105,5 +139,13 @@ func WithVerifySubscriberURL(url string) Option {
 func WithLogoURL(url string) Option {
 	return func(t *Config) {
 		t.LogoURL = url
+	}
+}
+
+// WithTemplatesPath allows you configure the path to your templates
+// else we will use the default templates
+func WithTemplatesPath(p string) Option {
+	return func(c *Config) {
+		c.templatesPath = p
 	}
 }

--- a/options.go
+++ b/options.go
@@ -25,7 +25,7 @@ func (c *Config) validate() error {
 		return newMissingRequiredFieldError("company name")
 	}
 
-	if len(c.FromEmail) == 0 {
+	if c.FromEmail == "" {
 		return newMissingRequiredFieldError("sender email")
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -102,7 +102,7 @@ func TestOptions(t *testing.T) {
 		cfg := &Config{}
 		opt := WithTemplatesPath("./custom/templates")
 		opt(cfg)
-		assert.Equal(t, "./custom/templates", cfg.templatesPath)
+		assert.Equal(t, "./custom/templates", cfg.TemplatesPath)
 	})
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -114,45 +114,39 @@ func TestNew(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name:    "missing templates path",
-			options: []Option{WithTemplatesPath("")},
-			wantErr: true,
-			errMsg:  "please provide your templates path",
-		},
-		{
 			name: "missing company address",
 			options: []Option{
-				WithTemplatesPath("./templates"),
+				WithTemplatesPath("./testdata"),
 				WithCompanyName("Test Company"),
 				WithFromEmail("test@example.com"),
 			},
 			wantErr: true,
-			errMsg:  "please provide your company's address",
+			errMsg:  "company address is required",
 		},
 		{
 			name: "missing company name",
 			options: []Option{
-				WithTemplatesPath("./templates"),
+				WithTemplatesPath("./testdata"),
 				WithCompanyAddress("123 Test St"),
 				WithFromEmail("test@example.com"),
 			},
 			wantErr: true,
-			errMsg:  "please provide your company's name",
+			errMsg:  "company name is required",
 		},
 		{
 			name: "missing from email",
 			options: []Option{
-				WithTemplatesPath("./templates"),
+				WithTemplatesPath("./testdata"),
 				WithCompanyAddress("123 Test St"),
 				WithCompanyName("Test Company"),
 			},
 			wantErr: true,
-			errMsg:  "please provide your sender email",
+			errMsg:  "sender email is required",
 		},
 		{
 			name: "invalid from email",
 			options: []Option{
-				WithTemplatesPath("./templates"),
+				WithTemplatesPath("./testdata"),
 				WithCompanyAddress("123 Test St"),
 				WithCompanyName("Test Company"),
 				WithFromEmail("invalid-email"),
@@ -163,12 +157,22 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid configuration",
 			options: []Option{
-				WithTemplatesPath("./templates"),
+				WithTemplatesPath("./testdata"),
 				WithCompanyAddress("123 Test St"),
 				WithCompanyName("Test Company"),
 				WithFromEmail("test@example.com"),
 			},
 			wantErr: false,
+		},
+		{
+			name: "missing templates path",
+			options: []Option{
+				WithTemplatesPath(""),
+				WithCompanyAddress("123 Test St"),
+				WithCompanyName("Test Company"),
+				WithFromEmail("test@example.com"),
+			},
+			wantErr: false, // no templates, the default ones will be used
 		},
 	}
 
@@ -179,6 +183,7 @@ func TestNew(t *testing.T) {
 				assert.Error(t, err)
 				assert.Equal(t, tt.errMsg, err.Error())
 				assert.Nil(t, cfg)
+
 				return
 			}
 

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,189 @@
+package emailtemplates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	t.Run("WithCompanyName", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithCompanyName("Test Company")
+		opt(cfg)
+		assert.Equal(t, "Test Company", cfg.CompanyName)
+	})
+
+	t.Run("WithCompanyAddress", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithCompanyAddress("123 Test St")
+		opt(cfg)
+		assert.Equal(t, "123 Test St", cfg.CompanyAddress)
+	})
+
+	t.Run("WithCorporation", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithCorporation("Test Corp")
+		opt(cfg)
+		assert.Equal(t, "Test Corp", cfg.Corporation)
+	})
+
+	t.Run("WithRootDomain", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithRootDomain("https://example.com")
+		opt(cfg)
+		assert.Equal(t, "https://example.com", cfg.URLS.Root)
+	})
+
+	t.Run("WithProductDomain", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithProductDomain("https://product.example.com")
+		opt(cfg)
+		assert.Equal(t, "https://product.example.com", cfg.URLS.Product)
+	})
+
+	t.Run("WithDocsDomain", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithDocsDomain("https://docs.theopenlane.io")
+		opt(cfg)
+		assert.Equal(t, "https://docs.theopenlane.io", cfg.URLS.Docs)
+	})
+
+	t.Run("WithFromEmail", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithFromEmail("test@test.com")
+		opt(cfg)
+		assert.Equal(t, "test@test.com", cfg.FromEmail)
+	})
+
+	t.Run("WithSupportEmail", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithSupportEmail("support@theopenlane.io")
+		opt(cfg)
+		assert.Equal(t, "support@theopenlane.io", cfg.SupportEmail)
+	})
+
+	t.Run("WithVerifyURL", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithVerifyURL("https://example.com/verify")
+		opt(cfg)
+		assert.Equal(t, "https://example.com/verify", cfg.URLS.Verify)
+	})
+
+	t.Run("WithInviteURL", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithInviteURL("https://example.com/invite")
+		opt(cfg)
+		assert.Equal(t, "https://example.com/invite", cfg.URLS.Invite)
+	})
+
+	t.Run("WithResetURL", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithResetURL("https://example.com/reset")
+		opt(cfg)
+		assert.Equal(t, "https://example.com/reset", cfg.URLS.PasswordReset)
+	})
+
+	t.Run("WithVerifySubscriberURL", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithVerifySubscriberURL("https://example.com/verify-subscriber")
+		opt(cfg)
+		assert.Equal(t, "https://example.com/verify-subscriber", cfg.URLS.VerifySubscriber)
+	})
+
+	t.Run("WithLogoURL", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithLogoURL("https://example.com/logo.png")
+		opt(cfg)
+		assert.Equal(t, "https://example.com/logo.png", cfg.LogoURL)
+	})
+
+	t.Run("WithTemplatesPath", func(t *testing.T) {
+		cfg := &Config{}
+		opt := WithTemplatesPath("./custom/templates")
+		opt(cfg)
+		assert.Equal(t, "./custom/templates", cfg.templatesPath)
+	})
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "missing templates path",
+			options: []Option{WithTemplatesPath("")},
+			wantErr: true,
+			errMsg:  "please provide your templates path",
+		},
+		{
+			name: "missing company address",
+			options: []Option{
+				WithTemplatesPath("./templates"),
+				WithCompanyName("Test Company"),
+				WithFromEmail("test@example.com"),
+			},
+			wantErr: true,
+			errMsg:  "please provide your company's address",
+		},
+		{
+			name: "missing company name",
+			options: []Option{
+				WithTemplatesPath("./templates"),
+				WithCompanyAddress("123 Test St"),
+				WithFromEmail("test@example.com"),
+			},
+			wantErr: true,
+			errMsg:  "please provide your company's name",
+		},
+		{
+			name: "missing from email",
+			options: []Option{
+				WithTemplatesPath("./templates"),
+				WithCompanyAddress("123 Test St"),
+				WithCompanyName("Test Company"),
+			},
+			wantErr: true,
+			errMsg:  "please provide your sender email",
+		},
+		{
+			name: "invalid from email",
+			options: []Option{
+				WithTemplatesPath("./templates"),
+				WithCompanyAddress("123 Test St"),
+				WithCompanyName("Test Company"),
+				WithFromEmail("invalid-email"),
+			},
+			wantErr: true,
+			errMsg:  "please provide a valid sender email ( from email )",
+		},
+		{
+			name: "valid configuration",
+			options: []Option{
+				WithTemplatesPath("./templates"),
+				WithCompanyAddress("123 Test St"),
+				WithCompanyName("Test Company"),
+				WithFromEmail("test@example.com"),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := New(tt.options...)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errMsg, err.Error())
+				assert.Nil(t, cfg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}

--- a/templates.go
+++ b/templates.go
@@ -34,7 +34,7 @@ type Config struct {
 	// URLS includes URLs that are used in the email templates
 	URLS URLConfig `koanf:"urls" json:"urls"`
 
-	templatesPath string
+	TemplatesPath string `koanf:"templatesPath" json:"templatesPath"`
 }
 
 // URLConfig includes urls that are used in the email templates

--- a/templates.go
+++ b/templates.go
@@ -33,6 +33,8 @@ type Config struct {
 	LogoURL string `koanf:"logoURL" json:"logoURL" default:""`
 	// URLS includes URLs that are used in the email templates
 	URLS URLConfig `koanf:"urls" json:"urls"`
+
+	templatesPath string
 }
 
 // URLConfig includes urls that are used in the email templates

--- a/templates_test.go
+++ b/templates_test.go
@@ -200,3 +200,49 @@ func TestSubscribe(t *testing.T) {
 
 	assert.Equal(t, "You've been subscribed to Test Company", email.Subject)
 }
+
+func TestWelcomeWithNew(t *testing.T) {
+	cfg, err := New(
+		WithTemplatesPath("testdata"),
+		WithCompanyName("Test Company"),
+		WithCompanyAddress("123 Test St"),
+		WithFromEmail("test@example.com"),
+	)
+	require.NoError(t, err)
+
+	r := Recipient{
+		Email: "test@example.com",
+	}
+
+	email, err := cfg.NewWelcomeEmail(r, "Test Org")
+	require.NoError(t, err)
+	require.NotNil(t, email)
+
+	assert.Equal(t, "custom welcome email template\n", email.HTML)
+}
+
+func TestInviteWithNew(t *testing.T) {
+	cfg, err := New(
+		WithTemplatesPath("testdata"),
+		WithCompanyName("Test Company"),
+		WithCompanyAddress("123 Test St"),
+		WithFromEmail("test@example.com"),
+	)
+	require.NoError(t, err)
+
+	r := Recipient{
+		Email: "test@example.com",
+	}
+
+	i := InviteTemplateData{
+		InviterName:      "John Doe",
+		OrganizationName: "Test Org",
+		Role:             "Admin",
+	}
+
+	email, err := cfg.NewInviteEmail(r, i, "test-token")
+	require.NoError(t, err)
+	require.NotNil(t, email)
+
+	assert.Equal(t, "custom invite email template\n", email.HTML)
+}

--- a/templates_test.go
+++ b/templates_test.go
@@ -246,3 +246,43 @@ func TestInviteWithNew(t *testing.T) {
 
 	assert.Equal(t, "custom invite email template\n", email.HTML)
 }
+
+func TestWelcomeWithNewDefaultTemplate(t *testing.T) {
+	cfg, err := New(
+		WithCompanyName("Test Company"),
+		WithCompanyAddress("123 Test St"),
+		WithFromEmail("test@example.com"),
+	)
+	require.NoError(t, err)
+
+	r := Recipient{
+		Email: "test@example.com",
+	}
+
+	email, err := cfg.NewWelcomeEmail(r, "Test Org")
+	require.NoError(t, err)
+	require.NotNil(t, email)
+}
+
+func TestInviteWithNewDefaultTemplate(t *testing.T) {
+	cfg, err := New(
+		WithCompanyName("Test Company"),
+		WithCompanyAddress("123 Test St"),
+		WithFromEmail("test@example.com"),
+	)
+	require.NoError(t, err)
+
+	r := Recipient{
+		Email: "test@example.com",
+	}
+
+	i := InviteTemplateData{
+		InviterName:      "John Doe",
+		OrganizationName: "Test Org",
+		Role:             "Admin",
+	}
+
+	email, err := cfg.NewInviteEmail(r, i, "test-token")
+	require.NoError(t, err)
+	require.NotNil(t, email)
+}

--- a/testdata/invite.html
+++ b/testdata/invite.html
@@ -1,0 +1,1 @@
+custom invite email template

--- a/testdata/welcome.html
+++ b/testdata/welcome.html
@@ -1,0 +1,1 @@
+custom welcome email template


### PR DESCRIPTION
It defaults to the existing `templates` path while also allowing a custom path to be passed. 

Also added tests